### PR TITLE
Fixing copyBuildLink URL

### DIFF
--- a/src/Misc/BuildImportExport.js
+++ b/src/Misc/BuildImportExport.js
@@ -132,7 +132,7 @@ export function copyBuildLink(parts) {
 				acc + '-' + id,
 		''
 	);
-	const url = window.location.origin + '/search?build=' + idString;
+	const url = window.location.origin + window.location.pathname + '?build=' + idString;
 	const promise = navigator.clipboard.writeText(url);
 	promise.then(() => glob.notify('Link copied to clipboard'));
 }


### PR DESCRIPTION
Hiya 👋 Nice website for Armored Core 6 Builder. Just want to quickly raise a PR regarding the Build Link issue I have faced

### Error replication

1. Visit https://matteosal.github.io/ac6-advanced-garage/
2. Click "CREATE BUILD LINK" iccon at the bottom-left
3. The value copied to the clipboard is `https://matteosal.github.io/search?build=64-37-8-231-115-135-150-168-196-205-214-233`
4. enter this in a new window in the web browser. Got 404 suggesting "There isn't a GitHub Page site here"
5. Slightly modifying the link to `https://matteosal.github.io/ac6-advanced-garage/?build=64-37-8-231-115-135-150-168-196-205-214-233` would work however

This issue doesn't appear in local build

### Test

Change is tested locally:
1. With `npm start` I got to `http://localhost:3000/ac6-advanced-garage` as base url.
2. Change R-arm unit to Jvln Alpha
3. With the fork build my copied url is  `http://localhost:3000/ac6-advanced-garage?build=0-37-8-231-115-135-150-168-196-205-214-233` which works locally. 
4. Replacing `localhost:3000` with `https://matteosal.github.io` leads me to your hosted github page

![image](https://github.com/user-attachments/assets/e406c27b-dcaa-4a2d-bfde-3a0df4ecf177)





 